### PR TITLE
add benchmark for encoding RGBA64 images

### DIFF
--- a/farbfeld.go
+++ b/farbfeld.go
@@ -39,19 +39,7 @@ func Encode(w io.Writer, img image.Image) error {
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
 			c := color.NRGBA64Model.Convert(img.At(x, y)).(color.NRGBA64)
-			err = binary.Write(bw, binary.BigEndian, c.R)
-			if err != nil {
-				return err
-			}
-			err = binary.Write(bw, binary.BigEndian, c.G)
-			if err != nil {
-				return err
-			}
-			err = binary.Write(bw, binary.BigEndian, c.B)
-			if err != nil {
-				return err
-			}
-			err = binary.Write(bw, binary.BigEndian, c.A)
+			err = binary.Write(bw, binary.BigEndian, [...]uint16{c.R, c.G, c.B, c.A})
 			if err != nil {
 				return err
 			}

--- a/farbfeld_test.go
+++ b/farbfeld_test.go
@@ -104,8 +104,17 @@ func TestQuickCheck(t *testing.T) {
 	}
 }
 
-func BenchmarkEncode(b *testing.B) {
+func BenchmarkEncodeNRGBA64(b *testing.B) {
 	img := image.NewNRGBA64(image.Rect(0, 0, 1<<10, 1<<10))
+	io.ReadFull(rand.Reader, img.Pix)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Encode(ioutil.Discard, img)
+	}
+}
+
+func BenchmarkEncodeRGBA64(b *testing.B) {
+	img := image.NewRGBA64(image.Rect(0, 0, 1<<10, 1<<10))
 	io.ReadFull(rand.Reader, img.Pix)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/farbfeld_test.go
+++ b/farbfeld_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"image"
-	"image/color"
 	"image/png"
 	"io"
 	"io/ioutil"
@@ -12,29 +11,6 @@ import (
 	"strings"
 	"testing"
 	"testing/quick"
-)
-
-// TODO: add more tests, in updated format.
-var (
-	imageData   = []byte("farbfeld")
-	red         = color.RGBA{255, 0, 0, 255}
-	green       = color.RGBA{0, 255, 0, 255}
-	blue        = color.RGBA{0, 0, 255, 255}
-	grayTr      = color.RGBA{128, 128, 128, 128}
-	imagePixels = [3][3]color.RGBA{
-		{red, green, blue},
-		{blue, grayTr, green},
-		{green, blue, red},
-	}
-	red64         = color.RGBA64{65535, 0, 0, 65535}
-	green64       = color.RGBA64{0, 65535, 0, 65535}
-	blue64        = color.RGBA64{0, 0, 65535, 65535}
-	grayTr64      = color.RGBA64{32768, 32768, 32768, 32768}
-	imagePixels64 = [3][3]color.RGBA64{
-		{red64, green64, blue64},
-		{blue64, grayTr64, green64},
-		{green64, blue64, red64},
-	}
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
also delete unused variables in  farbfeld_test.go
